### PR TITLE
Have TestLoggerFactoryResetRule reset the state prior to tests.

### DIFF
--- a/src/main/java/uk/org/lidalia/slf4jtest/TestLoggerFactoryResetRule.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/TestLoggerFactoryResetRule.java
@@ -25,6 +25,7 @@ public class TestLoggerFactoryResetRule implements TestRule {
 
         @Override
         public void evaluate() throws Throwable {
+            TestLoggerFactory.clear();
             try {
                 base.evaluate();
             } finally {

--- a/src/test/java/uk/org/lidalia/slf4jtest/TestLoggerFactoryResetRuleUnitTests.java
+++ b/src/test/java/uk/org/lidalia/slf4jtest/TestLoggerFactoryResetRuleUnitTests.java
@@ -25,7 +25,24 @@ public class TestLoggerFactoryResetRuleUnitTests {
     TestLoggerFactoryResetRule resetRule = new TestLoggerFactoryResetRule();
 
     @Test
-    public void resetsThreadLocalData() throws Throwable {
+    public void resetsThreadLocalDataBeforeTest() throws Throwable {
+
+        final TestLogger logger = TestLoggerFactory.getTestLogger("logger_name");
+        logger.setEnabledLevels(INFO, DEBUG);
+        logger.info("a message");
+
+        resetRule.apply(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+            	assertThat(TestLoggerFactory.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
+            	assertThat(logger.getLoggingEvents(), is(Collections.<LoggingEvent>emptyList()));
+            	assertThat(logger.getEnabledLevels(), is(Level.enablableValueSet()));
+            }
+        }, Description.EMPTY).evaluate();
+    }
+    
+    @Test
+    public void resetsThreadLocalDataAfterTest() throws Throwable {
 
         final TestLogger logger = TestLoggerFactory.getTestLogger("logger_name");
         logger.setEnabledLevels(INFO, DEBUG);


### PR DESCRIPTION
The commit message explains it:

> Previously, `TestLoggerFactoryResetRule` would only reset the thread-local state after each test. As a result the very first test in a class managed by this rule could encounter state left over from logging activity that commenced outside the rule's scope (typically as part of a test in some other class not managed by `TestLoggerFactoryResetRule`).
> 
> This fix ensures that `TestLoggerFactoryResetRule` establishes the invariant that the thread-local state before any test is empty. Strictly speaking we could remove the post-execution cleanup, but code outside this rule's scope might rely on the existing behavior. Deleting said statement might break existing tests and that's probably not worth the trouble.

Let me know what you think :)