### PR TITLE
Allowing message field to be null to match SLF4J behavior

### DIFF
--- a/src/main/java/uk/org/lidalia/slf4jtest/LoggingEvent.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/LoggingEvent.java
@@ -324,7 +324,7 @@ public class LoggingEvent extends RichObject {
         this.mdc = ImmutableMap.copyOf(mdc);
         this.marker = checkNotNull(marker);
         this.throwable = checkNotNull(throwable);
-        this.message = checkNotNull(message);
+        this.message = message;
         this.arguments = from(asList(arguments)).transform(TO_NON_NULL_VALUE).toList();
     }
 
@@ -339,7 +339,7 @@ public class LoggingEvent extends RichObject {
     @Identity private final ImmutableMap<String, String> mdc;
     @Identity private final Optional<Marker> marker;
     @Identity private final Optional<Throwable> throwable;
-    @Identity private final String message;
+    @Identity /* @Nullable */ private final String message;
     @Identity private final ImmutableList<Object> arguments;
 
     private final Optional<TestLogger> creatingLogger;

--- a/src/test/java/uk/org/lidalia/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/uk/org/lidalia/slf4jtest/LoggingEventTests.java
@@ -27,6 +27,7 @@ import static java.lang.System.lineSeparator;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -526,6 +527,12 @@ public class LoggingEventTests {
     public void nullArgument() {
         LoggingEvent event = new LoggingEvent(level, "message with null arg", null, null);
         assertThat(event, is(new LoggingEvent(level, "message with null arg", absent(), absent())));
+    }
+
+    @Test
+    public void nullMessage() {
+        LoggingEvent event = new LoggingEvent(level, null);
+        assertThat(event.getMessage(), nullValue());
     }
 
     @After


### PR DESCRIPTION
(not really documented in Slf4j)

Quick stab at fixing #11. Comments welcome.
