### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -7,15 +7,15 @@ import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public final class StaticLoggerBinder implements LoggerFactoryBinder {
 
+    public static final String REQUESTED_API_VERSION = "1.6";
+
     private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
+
+    private StaticLoggerBinder() { }
 
     public static StaticLoggerBinder getSingleton() {
         return SINGLETON;
     }
-
-    public static final String REQUESTED_API_VERSION = "1.6";
-
-    private StaticLoggerBinder() { }
 
     public ILoggerFactory getLoggerFactory() {
         return TestLoggerFactory.getInstance();

--- a/src/main/java/uk/org/lidalia/slf4jtest/OverridableProperties.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/OverridableProperties.java
@@ -15,17 +15,6 @@ class OverridableProperties {
     private final String propertySourceName;
     private final Properties properties;
 
-    OverridableProperties(final String propertySourceName) throws IOException {
-        this.propertySourceName = propertySourceName;
-        this.properties = getProperties();
-    }
-
-    private Properties getProperties() throws IOException {
-        final Optional<InputStream> resourceAsStream = fromNullable(Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream(propertySourceName + ".properties"));
-        return resourceAsStream.transform(loadProperties).or(EMPTY_PROPERTIES);
-    }
-
     private static final Function<InputStream, Properties> loadProperties = new Function<InputStream, Properties>() {
         @Override
         public Properties apply(final InputStream propertyResource) {
@@ -38,6 +27,17 @@ class OverridableProperties {
             }
         }
     };
+
+    OverridableProperties(final String propertySourceName) throws IOException {
+        this.propertySourceName = propertySourceName;
+        this.properties = getProperties();
+    }
+
+    private Properties getProperties() throws IOException {
+        final Optional<InputStream> resourceAsStream = fromNullable(Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream(propertySourceName + ".properties"));
+        return resourceAsStream.transform(loadProperties).or(EMPTY_PROPERTIES);
+    }
 
     String getProperty(final String propertyKey, final String defaultValue) {
         final String propertyFileProperty = properties.getProperty(propertyKey, defaultValue);

--- a/src/main/java/uk/org/lidalia/slf4jtest/Suppliers.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/Suppliers.java
@@ -9,6 +9,10 @@ import java.util.Map;
 
 final class Suppliers {
 
+    private Suppliers() {
+        throw new UnsupportedOperationException("Not instantiable");
+    }
+
     static <T> Supplier<List<T>> makeEmptyMutableList() {
         return new Supplier<List<T>>() {
             @Override
@@ -27,7 +31,4 @@ final class Suppliers {
         };
     }
 
-    private Suppliers() {
-        throw new UnsupportedOperationException("Not instantiable");
-    }
 }

--- a/src/main/java/uk/org/lidalia/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/TestLoggerFactory.java
@@ -21,8 +21,21 @@ import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class TestLoggerFactory implements ILoggerFactory {
-
     private static final LazyValue<TestLoggerFactory> INSTANCE = new LazyValue<>(new TestLoggerFactoryMaker());
+
+    private final ConcurrentMap<String, TestLogger> loggers = new ConcurrentHashMap<>();
+    private final List<LoggingEvent> allLoggingEvents = new CopyOnWriteArrayList<>();
+    private final ThreadLocal<List<LoggingEvent>> loggingEvents =
+            new ThreadLocal<>(Suppliers.<LoggingEvent>makeEmptyMutableList());
+    private volatile Level printLevel;
+
+    public TestLoggerFactory() {
+        this(Level.OFF);
+    }
+
+    public TestLoggerFactory(final Level printLevel) {
+        this.printLevel = checkNotNull(printLevel);
+    }
 
     public static TestLoggerFactory getInstance() {
         return INSTANCE.call();
@@ -58,20 +71,6 @@ public final class TestLoggerFactory implements ILoggerFactory {
 
     public static List<LoggingEvent> getAllLoggingEvents() {
         return getInstance().getAllLoggingEventsFromLoggers();
-    }
-
-    private final ConcurrentMap<String, TestLogger> loggers = new ConcurrentHashMap<>();
-    private final List<LoggingEvent> allLoggingEvents = new CopyOnWriteArrayList<>();
-    private final ThreadLocal<List<LoggingEvent>> loggingEvents =
-            new ThreadLocal<>(Suppliers.<LoggingEvent>makeEmptyMutableList());
-    private volatile Level printLevel;
-
-    public TestLoggerFactory() {
-        this(Level.OFF);
-    }
-
-    public TestLoggerFactory(final Level printLevel) {
-        this.printLevel = checkNotNull(printLevel);
     }
 
     public Level getPrintLevel() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat
