### PR TITLE
Added TestLoggerRule

### DIFF
--- a/src/main/java/uk/org/lidalia/slf4jtest/TestLoggerRule.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/TestLoggerRule.java
@@ -1,0 +1,104 @@
+package uk.org.lidalia.slf4jtest;
+
+import com.google.common.base.Optional;
+import junit.framework.AssertionFailedError;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import uk.org.lidalia.slf4jext.Level;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestLoggerRule implements TestRule {
+    private final TestLogger logger;
+    private List<ExpectedLogEvent> expectedEvents = new LinkedList<>();
+
+    public TestLoggerRule(Class<?> aClass) {
+        logger = TestLoggerFactory.getTestLogger(aClass);
+    }
+
+    public static TestLoggerRule forClass(Class<?> aClass) {
+        return new TestLoggerRule(aClass);
+    }
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                    verify();
+                } finally {
+                    after();
+                }
+            }
+        };
+    }
+
+    private void after() {
+        logger.clear();
+    }
+
+    private void verify() {
+        while (!expectedEvents.isEmpty()) {
+            ExpectedLogEvent expectedLogEvent = expectedEvents.remove(0);
+            boolean found = false;
+            for (LoggingEvent loggingEvent : logger.getLoggingEvents()) {
+                if (expectedLogEvent.matches(loggingEvent)) {
+                    found = true;
+                }
+            }
+            if (!found) {
+                throw new AssertionFailedError("Expected " + expectedLogEvent);
+            }
+        }
+    }
+
+    public void expectMessage(Level level) {
+        expectMessage(level, "");
+    }
+
+    public void expectMessage(Level level, String msg) {
+        expectMessage(level, msg, null);
+    }
+
+    public void expectMessage(Level level, String msg, Class<? extends Throwable> throwableClass) {
+        expectedEvents.add(new ExpectedLogEvent(level, msg, throwableClass));
+    }
+
+    private final static class ExpectedLogEvent {
+        private final String message;
+        private final Level level;
+        private final Class<? extends Throwable> throwableClass;
+
+        private ExpectedLogEvent(Level level, String message, Class<? extends Throwable> throwableClass) {
+            this.message = message;
+            this.level = level;
+            this.throwableClass = throwableClass;
+        }
+
+        private boolean matches(LoggingEvent actual) {
+            boolean match = actual.getMessage().contains(message);
+            match &= actual.getLevel().equals(level);
+            match &= matchThrowables(actual);
+            return match;
+        }
+
+        private boolean matchThrowables(LoggingEvent actual) {
+            Optional<Throwable> eventProxy = actual.getThrowable();
+            return throwableClass == null || eventProxy != null && throwableClass.getName().equals(eventProxy.get().getClass().getName());
+        }
+
+        @Override
+        public String toString() {
+            return "ExpectedLogEvent{" +
+                    "message='" + message + '\'' +
+                    ", level=" + level +
+                    ", throwableClass=" + throwableClass +
+                    '}';
+        }
+    }
+
+}

--- a/src/test/java/uk/org/lidalia/slf4jtest/TestLoggerRuleTest.java
+++ b/src/test/java/uk/org/lidalia/slf4jtest/TestLoggerRuleTest.java
@@ -1,0 +1,49 @@
+package uk.org.lidalia.slf4jtest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static uk.org.lidalia.slf4jext.Level.INFO;
+
+public class TestLoggerRuleTest {
+    @Rule
+    public TestLoggerRule testSubject = TestLoggerRule.forClass(Slf4jUser.class);
+
+    Slf4jUser slf4jUser = new Slf4jUser();
+
+    @Test
+    public void expectMessage_InfoMessage() throws Exception {
+        testSubject.expectMessage(INFO, "Hello World!");
+
+        slf4jUser.aMethodThatInfoLogs();
+    }
+
+    @Test
+    public void expectMessage_InfoMessageAndException() throws Exception {
+        testSubject.expectMessage(INFO, "Hello World!", Exception.class);
+
+        slf4jUser.aMethodThatInfoLogsWithException();
+    }
+
+    @Test
+    public void expectMessage_WhenLogNotCalled() throws Exception {
+        slf4jUser.aMethodThatDoesNotLog();
+    }
+
+    private static class Slf4jUser {
+        private static final Logger logger = LoggerFactory.getLogger(Slf4jUser.class);
+
+        public void aMethodThatInfoLogs() {
+            logger.info("Hello World!");
+        }
+
+        public void aMethodThatInfoLogsWithException() {
+            logger.info("Hello World!", new Exception());
+        }
+
+        public void aMethodThatDoesNotLog() {
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I really like the slf4j-test implementation of slf4j and it gets around a number of issues for testing logging in any environment. 

But I am partial to JUnit Rules.
I prefer to setup up expectations in a rule and then have the rule take care of it for me. Plus I don't have to clear the logger (although I did see the Rule that was there to do that for me).

I have some more ideas around this rule feature:
- Strict/lazy checking (strict would fail if you had unexpected logs, lazy would fail if had expected logs and they were not logged, but wouldn't care if their were other logs).
- Regular expression matching of messages.
- Level At Least (atLeast(INFO), which would pass if the Level was Info, Warn, Error, etc)
- Ability to control the expected level from the Rule

Just some of them
Adrian