### PR TITLE
Add markers and mdc formatting to LoggingEvent.print()

### DIFF
--- a/src/main/java/uk/org/lidalia/slf4jtest/LoggingEvent.java
+++ b/src/main/java/uk/org/lidalia/slf4jtest/LoggingEvent.java
@@ -409,7 +409,25 @@ public class LoggingEvent extends RichObject {
     }
 
     private String formatLogStatement() {
-        return getTimestamp() + " [" + getThreadName() + "] " + getLevel() + safeLoggerName() + " - " + getFormattedMessage();
+        return getTimestamp() + " [" + getThreadName() + "] " + getLevel() + safeLoggerName() + getFormattedMdc() + getFormattedMarkers() + " - " + getFormattedMessage();
+    }
+
+    private String getFormattedMdc() {
+        StringBuilder sb = new StringBuilder();
+        if (getMdc() != null) {
+            for (Map.Entry entry : getMdc().entrySet()) {
+                sb.append(" " + entry.getKey() + "=" + entry.getValue());
+            }
+        }
+        return sb.toString();
+    }
+
+    private String getFormattedMarkers() {
+        if (getMarker().isPresent()) {
+            return " " + marker.get().toString();
+        } else {
+            return "";
+        }
     }
 
     private String safeLoggerName() {

--- a/src/test/java/uk/org/lidalia/slf4jtest/LoggingEventTests.java
+++ b/src/test/java/uk/org/lidalia/slf4jtest/LoggingEventTests.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
+import org.slf4j.MarkerFactory;
 import uk.org.lidalia.slf4jext.Level;
 import uk.org.lidalia.test.StaticTimeRule;
 import uk.org.lidalia.test.SystemOutputRule;
@@ -56,7 +57,7 @@ public class LoggingEventTests {
         mdc.put("key", "value");
     }
 
-    Marker marker = mock(Marker.class);
+    Marker marker = MarkerFactory.getMarker("marker1");
     Throwable throwable = new Throwable();
     String message = "message";
     Object arg1 = "arg1";
@@ -520,6 +521,17 @@ public class LoggingEventTests {
         event.print();
         assertThat(systemOutputRule.getSystemErr(), is(not("")));
         assertThat(systemOutputRule.getSystemOut(), is(""));
+    }
+
+    @Test
+    @Parameters({"INFO"})
+    public void printInfoWithMDCAndMarkers(Level level) {
+        LoggingEvent event = new LoggingEvent(level, mdc, marker, "message");
+        event.print();
+        assertThat(systemOutputRule.getSystemOut(),
+            is("1970-01-01T00:00:00.000Z ["+Thread.currentThread().getName()+"] INFO key=value marker1 - message" + lineSeparator())
+        );
+
     }
 
     @Test


### PR DESCRIPTION
My team's code uses markers and MDC, and it would be helpful in our functional tests if the LoggingEvent.print() function could include these on Stdout.
